### PR TITLE
feat: add editable creature ID field with duplicate validation

### DIFF
--- a/Canary monster editor/Data.cs
+++ b/Canary monster editor/Data.cs
@@ -68,7 +68,7 @@ namespace Canary_monster_editor
                 return false;
             }
 
-            using (FileStream fileStream = new FileStream(GlobalStaticDataPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
+            using (FileStream fileStream = new FileStream(GlobalStaticDataPath, FileMode.Create, FileAccess.Write, FileShare.None))  
                 GlobalStaticData.WriteTo(fileStream);
 
             GlobalFileLastTimeEdited = File.GetLastWriteTime(GlobalStaticDataPath);

--- a/Canary monster editor/MainWindow.xaml
+++ b/Canary monster editor/MainWindow.xaml
@@ -155,7 +155,8 @@
                 <StackPanel Margin="0,25,0,0" Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Center">
                     <TextBlock x:Name="ShowName_textblock" Text="ShowName_textblock" Margin="0,0,5,0" IsHitTestVisible="False" Foreground="#FFACAFAF" VerticalAlignment="Center"/>
                     <TextBox x:Name="ShowName_textbox" TextChanged="TextChanged_textblock" Width="220" Background="#FF23242D" Foreground="#FFABADB3"/>
-                    <TextBlock x:Name="ShowRaceId_textblock" Text="ID: " Margin="10,0,5,0" IsHitTestVisible="False" Foreground="#FFACAFAF" VerticalAlignment="Center" FontSize="14"/>
+                    <TextBlock Text="ID: " Margin="10,0,5,0" IsHitTestVisible="False" Foreground="#FFACAFAF" VerticalAlignment="Center" FontSize="14"/>
+                    <TextBox x:Name="ShowRaceId_textbox" TextChanged="TextChanged_textblock" Width="75" Background="#FF23242D" Foreground="#FFABADB3"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,25,0,0" HorizontalAlignment="Center">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Center">

--- a/Canary monster editor/MainWindow.xaml.cs
+++ b/Canary monster editor/MainWindow.xaml.cs
@@ -304,8 +304,13 @@ namespace Canary_monster_editor
                             return;
                         }
 
-                        uint newRaceId = 0;
-                        bool idChanged = uint.TryParse(ShowRaceId_textbox.Text, out newRaceId) && newRaceId != monster.Raceid;
+                        if (!uint.TryParse(ShowRaceId_textbox.Text, out uint newRaceId) || newRaceId == 0) {
+                            MessageBox.Show("ID must be a valid positive number.",
+                                "Invalid ID", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            ShowRaceId_textbox.Text = monster.Raceid.ToString();
+                            return;
+                        }
+                        bool idChanged = newRaceId != monster.Raceid;
 
                         if (idChanged) {
                             Monster existingMonster = GetMonsterByRaceId(newRaceId);

--- a/Canary monster editor/MainWindow.xaml.cs
+++ b/Canary monster editor/MainWindow.xaml.cs
@@ -285,13 +285,39 @@ namespace Canary_monster_editor
                             }
 
                             monster.Name = ShowName_textbox.Text;
+
+                            uint newRaceId = 0;
+                            if (uint.TryParse(ShowRaceId_textbox.Text, out newRaceId) && newRaceId != monster.Raceid)
+                            {
+                                Monster existingMonster = GetMonsterByRaceId(newRaceId);
+                                if (existingMonster != null)
+                                {
+                                    MessageBox.Show($"ID {newRaceId} is already being used by another monster: {existingMonster.Name}",
+                                        "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                    ShowRaceId_textbox.Text = monster.Raceid.ToString();
+                                    return;
+                                }
+
+                                Boss existingBoss = GetBossById(newRaceId);
+                                if (existingBoss != null)
+                                {
+                                    MessageBox.Show($"ID {newRaceId} is already being used by a boss: {existingBoss.Name}",
+                                        "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                    ShowRaceId_textbox.Text = monster.Raceid.ToString();
+                                    return;
+                                }
+
+                                monster.Raceid = newRaceId;
+                                SelectedCreature.id = newRaceId;
+                            }
+
                             if (monster.AppearanceType == null) {
                                 monster.AppearanceType = new Appearance_Type();
                             }
 
                             uint parsedUint = 0;
                             uint.TryParse(ShowLookType_textbox.Text, out parsedUint);
-                            monster.AppearanceType.Outfittype = 0;
+                            monster.AppearanceType.Outfittype = parsedUint;
                             parsedUint = 0;
 
                             uint.TryParse(ShowAddon_textbox.Text, out parsedUint);
@@ -299,7 +325,7 @@ namespace Canary_monster_editor
                             parsedUint = 0;
 
                             if (monster.AppearanceType.Colors == null) {
-                                 monster.AppearanceType.Colors = new Tibia.Protobuf.Staticdata.Colors();
+                                monster.AppearanceType.Colors = new Tibia.Protobuf.Staticdata.Colors();
                             }
 
                             uint.TryParse(ShowLookHead_textbox.Text, out parsedUint);
@@ -328,6 +354,32 @@ namespace Canary_monster_editor
                             }
 
                             boss.Name = ShowName_textbox.Text;
+
+                            uint newBossId = 0;
+                            if (uint.TryParse(ShowRaceId_textbox.Text, out newBossId) && newBossId != boss.Id)
+                            {
+                                Boss existingBoss = GetBossById(newBossId);
+                                if (existingBoss != null)
+                                {
+                                    MessageBox.Show($"ID {newBossId} is already being used by another boss: {existingBoss.Name}",
+                                        "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                    ShowRaceId_textbox.Text = boss.Id.ToString();
+                                    return;
+                                }
+
+                                Monster existingMonster = GetMonsterByRaceId(newBossId);
+                                if (existingMonster != null)
+                                {
+                                    MessageBox.Show($"ID {newBossId} is already being used by a monster: {existingMonster.Name}",
+                                        "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                    ShowRaceId_textbox.Text = boss.Id.ToString();
+                                    return;
+                                }
+
+                                boss.Id = newBossId;
+                                SelectedCreature.id = newBossId;
+                            }
+
                             if (GlobalBossAppearancesObjects) {
                                 if (boss.AppearanceType == null) {
                                     boss.AppearanceType = new Appearance_Type();
@@ -627,7 +679,7 @@ namespace Canary_monster_editor
                     return;
                 }
 
-                ShowRaceId_textblock.Text = "ID: " + boss.Id.ToString();
+                ShowRaceId_textbox.Text = boss.Id.ToString();
                 SelectedCreature.name = boss.Name;
                 ShowName_textbox.Text = boss.Name;
 
@@ -665,7 +717,7 @@ namespace Canary_monster_editor
                     return;
                 }
 
-                ShowRaceId_textblock.Text = "ID: " + monster.Raceid.ToString();
+                ShowRaceId_textbox.Text = monster.Raceid.ToString();
                 SelectedCreature.name = monster.Name;
                 ShowName_textbox.Text = monster.Name;
 

--- a/Canary monster editor/MainWindow.xaml.cs
+++ b/Canary monster editor/MainWindow.xaml.cs
@@ -272,159 +272,165 @@ namespace Canary_monster_editor
                         break;
                     }
                 case "ShowSave_rectangle": {
-                        if (SelectedCreature == null || !HasChangeMade) {
+                    if (SelectedCreature == null || !HasChangeMade) {
+                        return;
+                    }
+
+                    if (SelectedListType_t == ListType.Monsters) {
+                        Monster monster = GetMonsterByRaceId(SelectedCreature.id);
+                        if (monster == null) {
                             return;
+                        }
+
+                        uint newRaceId = 0;
+                        bool idChanged = uint.TryParse(ShowRaceId_textbox.Text, out newRaceId) && newRaceId != monster.Raceid;
+
+                        if (idChanged) {
+                            Monster existingMonster = GetMonsterByRaceId(newRaceId);
+                            if (existingMonster != null) {
+                                MessageBox.Show($"ID {newRaceId} is already being used by another monster: {existingMonster.Name}",
+                                    "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                ShowRaceId_textbox.Text = monster.Raceid.ToString();
+                                return; 
+                            }
+
+                            Boss existingBoss = GetBossById(newRaceId);
+                            if (existingBoss != null) {
+                                MessageBox.Show($"ID {newRaceId} is already being used by a boss: {existingBoss.Name}",
+                                    "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                ShowRaceId_textbox.Text = monster.Raceid.ToString();
+                                return;
+                            }
                         }
 
                         HasChangeMade = false;
                         HasGlobalChangeMade = true;
-                        if (SelectedListType_t == ListType.Monsters) {
-                            Monster monster = GetMonsterByRaceId(SelectedCreature.id);
-                            if (monster == null) {
+
+                        monster.Name = ShowName_textbox.Text;
+
+                        if (idChanged) {
+                            monster.Raceid = newRaceId;
+                            SelectedCreature.id = newRaceId;
+                        }
+
+                        if (monster.AppearanceType == null) {
+                            monster.AppearanceType = new Appearance_Type();
+                        }
+
+                        uint parsedUint = 0;
+                        uint.TryParse(ShowLookType_textbox.Text, out parsedUint);
+                        monster.AppearanceType.Outfittype = parsedUint;
+                        parsedUint = 0;
+
+                        uint.TryParse(ShowAddon_textbox.Text, out parsedUint);
+                        monster.AppearanceType.Outfitaddon = parsedUint;
+                        parsedUint = 0;
+
+                        if (monster.AppearanceType.Colors == null) {
+                            monster.AppearanceType.Colors = new Tibia.Protobuf.Staticdata.Colors();
+                        }
+
+                        uint.TryParse(ShowLookHead_textbox.Text, out parsedUint);
+                        monster.AppearanceType.Colors.Lookhead = parsedUint;
+                        parsedUint = 0;
+
+                        uint.TryParse(ShowLookBody_textbox.Text, out parsedUint);
+                        monster.AppearanceType.Colors.Lookbody = parsedUint;
+                        parsedUint = 0;
+
+                        uint.TryParse(ShowLookLegs_textbox.Text, out parsedUint);
+                        monster.AppearanceType.Colors.Looklegs = parsedUint;
+                        parsedUint = 0;
+
+                        uint.TryParse(ShowLookFeet_textbox.Text, out parsedUint);
+                        monster.AppearanceType.Colors.Lookfeet = parsedUint;
+                        parsedUint = 0;
+
+                        uint.TryParse(ShowLookTypeEx_textbox.Text, out parsedUint);
+                        monster.AppearanceType.Itemtype = parsedUint;
+
+                    } else if (SelectedListType_t == ListType.Bosses) {
+                        Boss boss = GetBossById(SelectedCreature.id);
+                        if (boss == null) {
+                            return;
+                        }
+
+                        uint newBossId = 0;
+                        bool idChanged = uint.TryParse(ShowRaceId_textbox.Text, out newBossId) && newBossId != boss.Id;
+
+                        if (idChanged) {
+                            Boss existingBoss = GetBossById(newBossId);
+                            if (existingBoss != null) {
+                                MessageBox.Show($"ID {newBossId} is already being used by another boss: {existingBoss.Name}",
+                                    "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                ShowRaceId_textbox.Text = boss.Id.ToString();
                                 return;
                             }
 
-                            monster.Name = ShowName_textbox.Text;
-
-                            uint newRaceId = 0;
-                            if (uint.TryParse(ShowRaceId_textbox.Text, out newRaceId) && newRaceId != monster.Raceid)
-                            {
-                                Monster existingMonster = GetMonsterByRaceId(newRaceId);
-                                if (existingMonster != null)
-                                {
-                                    MessageBox.Show($"ID {newRaceId} is already being used by another monster: {existingMonster.Name}",
-                                        "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
-                                    ShowRaceId_textbox.Text = monster.Raceid.ToString();
-                                    return;
-                                }
-
-                                Boss existingBoss = GetBossById(newRaceId);
-                                if (existingBoss != null)
-                                {
-                                    MessageBox.Show($"ID {newRaceId} is already being used by a boss: {existingBoss.Name}",
-                                        "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
-                                    ShowRaceId_textbox.Text = monster.Raceid.ToString();
-                                    return;
-                                }
-
-                                monster.Raceid = newRaceId;
-                                SelectedCreature.id = newRaceId;
+                            Monster existingMonster = GetMonsterByRaceId(newBossId);
+                            if (existingMonster != null) {
+                                MessageBox.Show($"ID {newBossId} is already being used by a monster: {existingMonster.Name}",
+                                    "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
+                                ShowRaceId_textbox.Text = boss.Id.ToString();
+                                return;
                             }
+                        }
 
-                            if (monster.AppearanceType == null) {
-                                monster.AppearanceType = new Appearance_Type();
+                        HasChangeMade = false;
+                        HasGlobalChangeMade = true;
+
+                        boss.Name = ShowName_textbox.Text;  
+
+                        if (idChanged) {
+                            boss.Id = newBossId;
+                            SelectedCreature.id = newBossId;
+                        }
+
+                        if (GlobalBossAppearancesObjects) {
+                            if (boss.AppearanceType == null) {
+                                boss.AppearanceType = new Appearance_Type();
                             }
 
                             uint parsedUint = 0;
                             uint.TryParse(ShowLookType_textbox.Text, out parsedUint);
-                            monster.AppearanceType.Outfittype = parsedUint;
+                            boss.AppearanceType.Outfittype = parsedUint;
                             parsedUint = 0;
 
                             uint.TryParse(ShowAddon_textbox.Text, out parsedUint);
-                            monster.AppearanceType.Outfitaddon = parsedUint;
+                            boss.AppearanceType.Outfitaddon = parsedUint;
                             parsedUint = 0;
 
-                            if (monster.AppearanceType.Colors == null) {
-                                monster.AppearanceType.Colors = new Tibia.Protobuf.Staticdata.Colors();
+                            if (boss.AppearanceType.Colors == null) {
+                                boss.AppearanceType.Colors = new Tibia.Protobuf.Staticdata.Colors();
                             }
 
                             uint.TryParse(ShowLookHead_textbox.Text, out parsedUint);
-                            monster.AppearanceType.Colors.Lookhead = parsedUint;
+                            boss.AppearanceType.Colors.Lookhead = parsedUint;
                             parsedUint = 0;
 
                             uint.TryParse(ShowLookBody_textbox.Text, out parsedUint);
-                            monster.AppearanceType.Colors.Lookbody = parsedUint;
+                            boss.AppearanceType.Colors.Lookbody = parsedUint;
                             parsedUint = 0;
 
                             uint.TryParse(ShowLookLegs_textbox.Text, out parsedUint);
-                            monster.AppearanceType.Colors.Looklegs = parsedUint;
+                            boss.AppearanceType.Colors.Looklegs = parsedUint;
                             parsedUint = 0;
 
                             uint.TryParse(ShowLookFeet_textbox.Text, out parsedUint);
-                            monster.AppearanceType.Colors.Lookfeet = parsedUint;
+                            boss.AppearanceType.Colors.Lookfeet = parsedUint;
                             parsedUint = 0;
 
                             uint.TryParse(ShowLookTypeEx_textbox.Text, out parsedUint);
-                            monster.AppearanceType.Itemtype = parsedUint;
-
-                        } else if (SelectedListType_t == ListType.Bosses) {
-                            Boss boss = GetBossById(SelectedCreature.id);
-                            if (boss == null) {
-                                return;
-                            }
-
-                            boss.Name = ShowName_textbox.Text;
-
-                            uint newBossId = 0;
-                            if (uint.TryParse(ShowRaceId_textbox.Text, out newBossId) && newBossId != boss.Id)
-                            {
-                                Boss existingBoss = GetBossById(newBossId);
-                                if (existingBoss != null)
-                                {
-                                    MessageBox.Show($"ID {newBossId} is already being used by another boss: {existingBoss.Name}",
-                                        "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
-                                    ShowRaceId_textbox.Text = boss.Id.ToString();
-                                    return;
-                                }
-
-                                Monster existingMonster = GetMonsterByRaceId(newBossId);
-                                if (existingMonster != null)
-                                {
-                                    MessageBox.Show($"ID {newBossId} is already being used by a monster: {existingMonster.Name}",
-                                        "Duplicate ID", MessageBoxButton.OK, MessageBoxImage.Warning);
-                                    ShowRaceId_textbox.Text = boss.Id.ToString();
-                                    return;
-                                }
-
-                                boss.Id = newBossId;
-                                SelectedCreature.id = newBossId;
-                            }
-
-                            if (GlobalBossAppearancesObjects) {
-                                if (boss.AppearanceType == null) {
-                                    boss.AppearanceType = new Appearance_Type();
-                                }
-
-                                uint parsedUint = 0;
-                                uint.TryParse(ShowLookType_textbox.Text, out parsedUint);
-                                boss.AppearanceType.Outfittype = parsedUint;
-                                parsedUint = 0;
-
-                                uint.TryParse(ShowAddon_textbox.Text, out parsedUint);
-                                boss.AppearanceType.Outfitaddon = parsedUint;
-                                parsedUint = 0;
-
-                                if (boss.AppearanceType.Colors == null) {
-                                    boss.AppearanceType.Colors = new Tibia.Protobuf.Staticdata.Colors();
-                                }
-
-                                uint.TryParse(ShowLookHead_textbox.Text, out parsedUint);
-                                boss.AppearanceType.Colors.Lookhead = parsedUint;
-                                parsedUint = 0;
-
-                                uint.TryParse(ShowLookBody_textbox.Text, out parsedUint);
-                                boss.AppearanceType.Colors.Lookbody = parsedUint;
-                                parsedUint = 0;
-
-                                uint.TryParse(ShowLookLegs_textbox.Text, out parsedUint);
-                                boss.AppearanceType.Colors.Looklegs = parsedUint;
-                                parsedUint = 0;
-
-                                uint.TryParse(ShowLookFeet_textbox.Text, out parsedUint);
-                                boss.AppearanceType.Colors.Lookfeet = parsedUint;
-                                parsedUint = 0;
-
-                                uint.TryParse(ShowLookTypeEx_textbox.Text, out parsedUint);
-                                boss.AppearanceType.Itemtype = parsedUint;
-                            }
-                        } else {
-                            return;
+                            boss.AppearanceType.Itemtype = parsedUint;
                         }
-
-                        SelectedCreature.name = ShowName_textbox.Text;
-                        MainList_listbox.Items.Refresh();
-                        break;
+                    } else {
+                        return;
                     }
+
+                    SelectedCreature.name = ShowName_textbox.Text;
+                    MainList_listbox.Items.Refresh();
+                    break;
+                }
                 default:
                     break;
             }


### PR DESCRIPTION
## Overview  
  
This PR adds the ability to edit creature IDs directly in the editor interface, with comprehensive validation to prevent duplicate IDs and ensure atomic save operations.  
  
## Changes Made  
  
### Features Added  
- **Editable ID Field**: Replaced read-only `ShowRaceId_textblock` with editable `ShowRaceId_textbox` in MainWindow.xaml (line 158-159)  
- **Duplicate ID Validation**: Added validation logic that checks for duplicate IDs across both monsters and bosses before saving  
- **Cross-Entity Validation**: Validates that IDs are unique across both monster and boss collections to prevent conflicts in shared ID space  
- **User Feedback**: Shows warning dialogs when attempting to use an existing ID, displaying which creature currently uses that ID  
  
### Bug Fixes  
- **LookType Save Bug**: Fixed bug where `monster.AppearanceType.Outfittype` was always being saved as `0` instead of the parsed value from `ShowLookType_textbox` (line 294)  
- **Atomic Save Operations**: Reordered save logic to perform ID validation **before** mutating any state (monster.Name, boss.Name, global flags), preventing partial saves when validation fails  
  
### Technical Details  
  
**UI Changes:**  
- Modified `MainWindow.xaml` (line 158-159) to add editable TextBox with `TextChanged` event handler  
- Updated `ReloadShowGrid()` to populate TextBox for monsters (line 668) and bosses (line 630)  
  
**Validation Logic:**  
- Added ID validation in `ParseMainButtonClick()` case "ShowSave_rectangle" for both entity types  
- Validation uses existing `GetMonsterByRaceId()` and `GetBossById()` helper functions  
- Cross-validates between monsters and bosses to prevent ID conflicts  
- Introduced `idChanged` boolean flag to only apply ID updates when necessary  
  
**Save Order Fix:**  
- Moved ID validation to execute **before** setting `HasChangeMade = false` and `HasGlobalChangeMade = true`  
- Moved `monster.Name` and `boss.Name` assignments to execute **after** successful validation  
- Ensures no partial state modifications if validation returns early  
  
**Localization:**  
- Translated all validation error messages from Portuguese to English  
- Messages follow pattern: "ID {id} is already being used by another {type}: {name}"  
  
## Testing Performed  
  
- ✅ Tested ID editing for both monsters and bosses  
- ✅ Verified duplicate ID detection works correctly within same entity type  
- ✅ Verified cross-entity duplicate ID detection (monster vs boss)  
- ✅ Confirmed LookType now saves properly for monsters  
- ✅ Validated atomic save behavior (no partial saves on validation failure)  
- ✅ Confirmed compile functionality works with ID changes  
- ✅ Tested that `SelectedCreature.id` updates correctly in UI list  
  
## Important Notes  
  
⚠️ **Server-Side Impact**: Changing IDs of existing creatures may cause issues with server-side references (database, spawns, scripts, bestiary data). It's strongly recommended to:  
- Create new creatures with desired IDs rather than modifying existing ones  
- Stop the server before making ID changes  
- Update all server-side references (database, Lua scripts) if IDs are changed  
- Test thoroughly in a development environment first  
  
## Related Issues  
  
Fixes issues with:  
- Non-editable creature IDs limiting flexibility  
- Monster LookType field not saving correctly (introduced in commit [dd8d20fd](https://github.com/vllsystems/Canary-monster-editor/commit/dd8d20fd))  
- Partial saves leaving inconsistent state when validation fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Race ID field is now editable and updates lists immediately after a successful save
  * Name can be edited and saved from the UI

* **Bug Fixes**
  * Duplicate ID validation for Monsters and Bosses with warnings and UI revert on conflict
  * Prevents saving when no creature is selected or no changes detected

* **Improvements**
  * Unified appearance/outfit handling applied on save for both Monsters and Bosses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->